### PR TITLE
stop application if app has finished

### DIFF
--- a/fri3d/fri3d_application/src/payload/fri3d/application/app_info.py
+++ b/fri3d/fri3d_application/src/payload/fri3d/application/app_info.py
@@ -8,11 +8,11 @@ class AppInfo:
 
         self.name = configuration.get('name', None)
         if not self.name:
-            raise AttributeError(f"Required key `name` not found")
+            raise AttributeError("Required key `name` not found")
 
         self.cls = configuration.get('cls', None)
         if not self.cls:
-            raise AttributeError(f"Required key `cls` not found")
+            raise AttributeError("Required key `cls` not found")
 
         # Whether the app should be hidden from the launcher or not
         self.hidden = configuration.get('hidden', False)

--- a/fri3d/fri3d_application/src/payload/fri3d/application/application.py
+++ b/fri3d/fri3d_application/src/payload/fri3d/application/application.py
@@ -42,6 +42,8 @@ class Application:
 
         await self._app_manager.run_app(self._default_app)
 
+        self.running = False
+
         await tick
 
     def run(self):

--- a/fri3d/fri3d_application/src/payload/fri3d/apps/splash/splash.py
+++ b/fri3d/fri3d_application/src/payload/fri3d/apps/splash/splash.py
@@ -1,7 +1,7 @@
 import asyncio
 import lvgl as lv
 
-from fri3d.application import App
+from fri3d.application import App, AppInfo, Managers
 from fri3d.badge.leds import leds
 
 


### PR DESCRIPTION
if `app_manager.run_app()` is finished, we can stop the tick task as well (nothing will react to button input or other changes)

this will result in a REPL promt when the default app has finished